### PR TITLE
Fix too restrictive format version check

### DIFF
--- a/fontobene-qt5/header.h
+++ b/fontobene-qt5/header.h
@@ -58,7 +58,7 @@ struct Header {
                         if (format != QStringLiteral("FontoBene")) {
                             throw Exception(QString("Unknown format: \"%1\"").arg(format));
                         }
-                        if (formatVersion != QStringLiteral("1.0")) {
+                        if (!formatVersion.startsWith(QStringLiteral("1."))) {
                             throw Exception(QString("Unsupported format version: \"%1\"")
                                             .arg(formatVersion));
                         }


### PR DESCRIPTION
Currently the officially specified format version "1.0.0" was rejected because the only allowed format version was "1.0". Now all format versions starting with "1." are accepted.

But I'm not sure if this is the ideal solution. Should we accept e.g. a version "1.1.0" if the parser does not know what features were introduced in that version? Or should we only allow versions "1.0.x"? Or even "1.0.0"?

Of course the current check would even accept invalid versions like "1.foo"... However we finally implement it, we should do it *before* releasing this library :wink: