### PR TITLE
Don't pass "SkipEmptyParts" when splitting polylines

### DIFF
--- a/fontobene-qt5/glyph.h
+++ b/fontobene-qt5/glyph.h
@@ -39,7 +39,7 @@ struct Vertex {
 struct Polyline : public QVector<Vertex> {
     static Polyline fromString(const QString& str) {
         Polyline p;
-        foreach (const QString& vertex, str.split(';', QString::SkipEmptyParts)) {
+        foreach (const QString& vertex, str.split(';')) {
             p.append(Vertex::fromString(vertex));
         }
         return p;


### PR DESCRIPTION
The enum value "QString::SkipEmptyParts" produces a deprecation warning when compiling with Qt 5.15. And since actually it's not even needed to skip empty parts of the string, let's simply remove it. It just makes the parser slightly more strict, since now polylines containing empty vertices or a trailing semicolon are now rejected.

@dbrgn What do you think about this? An alternative would be to use a preprocessor conditional to avoid the deprecation warning...