### PR TITLE
Add support for CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,23 @@ jobs:
         run: cmake --build build -j8 -v
       - name: Run tests
         run: build/tests/fontobene-qt5-tests
+
+  test_cmake_3.5:
+    name: build and run tests with cmake
+    runs-on: ubuntu-16.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install qt and build tools
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config g++ make cmake \
+            qt5-default qttools5-dev-tools
+      - name: Run cmake
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build -j8 -v
+      - name: Run tests
+        run: build/tests/fontobene-qt5-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ name: CI
 
 jobs:
 
-  build_and_test:
-    name: build and run tests
+  test_qmake:
+    name: build and run tests with qmake
     runs-on: ubuntu-18.04
     env:
       DEBIAN_FRONTEND: noninteractive
@@ -21,5 +21,25 @@ jobs:
         run: mkdir build && cd build && qmake -r .. "QMAKE_CXXFLAGS=-Werror"
       - name: Build
         run: cd build && make -j8
+      - name: Run tests
+        run: build/tests/fontobene-qt5-tests
+
+  test_cmake:
+    name: build and run tests with cmake
+    runs-on: ubuntu-18.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install qt and build tools
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config g++ make cmake \
+            qt5-default qttools5-dev-tools
+      - name: Run cmake
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build -j8 -v
       - name: Run tests
         run: build/tests/fontobene-qt5-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
         run: build/tests/fontobene-qt5-tests
 
   test_cmake:
-    name: build and run tests with cmake
-    runs-on: ubuntu-18.04
+    name: build and run tests with cmake 3.16 (ubuntu 20.04)
+    runs-on: ubuntu-20.04
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -44,8 +44,8 @@ jobs:
       - name: Run tests
         run: build/tests/fontobene-qt5-tests
 
-  test_cmake_3.5:
-    name: build and run tests with cmake
+  test_cmake_min_version:
+    name: build and run tests with cmake 3.5 (ubuntu 16.04)
     runs-on: ubuntu-16.04
     env:
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,19 @@ name: CI
 
 jobs:
 
-  test_qmake:
-    name: build and run tests with qmake
-    runs-on: ubuntu-18.04
+  qmake:
+    name: "qmake on ${{ matrix.runner }}"
+    runs-on: "${{ matrix.runner }}"
+    strategy:
+      matrix:
+        runner:
+          - "ubuntu-16.04"
+          - "ubuntu-18.04"
+          - "ubuntu-20.04"
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install qt and build tools
         run: |
           sudo apt-get update &&
@@ -24,9 +30,15 @@ jobs:
       - name: Run tests
         run: build/tests/fontobene-qt5-tests
 
-  test_cmake:
-    name: build and run tests with cmake 3.16 (ubuntu 20.04)
-    runs-on: ubuntu-20.04
+  cmake:
+    name: "cmake on ${{ matrix.runner }}"
+    runs-on: "${{ matrix.runner }}"
+    strategy:
+      matrix:
+        runner:
+          - "ubuntu-16.04"
+          - "ubuntu-18.04"
+          - "ubuntu-20.04"
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -37,26 +49,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config g++ make cmake \
             qt5-default qttools5-dev-tools
-      - name: Run cmake
-        run: cmake -S . -B build
-      - name: Build
-        run: cmake --build build -j8 -v
-      - name: Run tests
-        run: build/tests/fontobene-qt5-tests
-
-  test_cmake_min_version:
-    name: build and run tests with cmake 3.5 (ubuntu 16.04)
-    runs-on: ubuntu-16.04
-    env:
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install qt and build tools
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y --no-install-recommends \
-            pkg-config g++ make cmake \
-            qt5-default qttools5-dev-tools
+      - name: Show cmake version
+        run: cmake --version
       - name: Run cmake
         run: cmake -S . -B build
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install qt and build tools
         run: |
           sudo apt-get update &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
 else()
     project(fontobene_qt5
         VERSION 0.1.0
-        DESCRIPTION "A header-only library to parse FontoBene stroke fonts with C++/Qt5."
+        DESCRIPTION "A header-only library to parse FontoBene stroke fonts with C++11/Qt5."
         HOMEPAGE_URL "https://github.com/fontobene/fontobene-qt5"
         LANGUAGES CXX
     )
@@ -21,6 +21,11 @@ endif()
 
 # Options
 option(FONTOBENE_ENABLE_TESTS "Build tests for fontobene-qt5." ON)
+
+# Use C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Find required Qt packages
 find_package(Qt5 5.2.0 COMPONENTS Core REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+# CMake version configuration
+cmake_minimum_required(VERSION 3.5...3.19)
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
+
+# Define project
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    project(fontobene_qt5
+        VERSION 0.1.0
+        LANGUAGES CXX
+    )
+else()
+    project(fontobene_qt5
+        VERSION 0.1.0
+        DESCRIPTION "A header-only library to parse FontoBene stroke fonts with C++/Qt5."
+        HOMEPAGE_URL "https://github.com/fontobene/fontobene-qt5"
+        LANGUAGES CXX
+    )
+endif()
+
+# Options
+option(FONTOBENE_ENABLE_TESTS "Build tests for fontobene-qt5." ON)
+
+# Find required Qt packages
+find_package(Qt5 5.2.0 COMPONENTS Core REQUIRED)
+
+# Include subprojects
+add_subdirectory(fontobene-qt5)
+if(FONTOBENE_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,10 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
 endif()
 
 # Define project
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-    project(fontobene_qt5
-        VERSION 0.1.0
-        LANGUAGES CXX
-    )
-else()
-    project(fontobene_qt5
-        VERSION 0.1.0
-        DESCRIPTION "A header-only library to parse FontoBene stroke fonts with C++11/Qt5."
-        HOMEPAGE_URL "https://github.com/fontobene/fontobene-qt5"
-        LANGUAGES CXX
-    )
-endif()
+project(fontobene_qt5
+    VERSION 0.1.0
+    LANGUAGES CXX
+)
 
 # Options
 option(FONTOBENE_ENABLE_TESTS "Build tests for fontobene-qt5." ON)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++/Qt5 FontoBene Parser
 
-A header-only library to parse FontoBene stroke fonts with C++/Qt5.
+A header-only library to parse FontoBene stroke fonts with C++11/Qt5.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ A header-only library to parse FontoBene stroke fonts with C++/Qt5.
 
 ## Installing
 
-    $ mkdir build
-    $ cd build
+### qmake
+
+    $ mkdir build && cd build
     $ qmake -r .. PREFIX=/usr
-    $ make
+    $ make -j8
+    $ tests/fontobene-qt5-tests
+    $ make install
+
+### cmake
+
+    $ mkdir build && cd build
+    $ cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+    $ make -j8
     $ tests/fontobene-qt5-tests
     $ make install
 

--- a/fontobene-qt5/CMakeLists.txt
+++ b/fontobene-qt5/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Add header-only library
+add_library(fontobene_qt5 INTERFACE)
+target_include_directories(fontobene_qt5
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<INSTALL_INTERFACE:include>
+)
+
+# Install target
+include(GNUInstallDirs)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Alias to namespaced variant
+add_library(FontoBene::FontoBeneQt5 ALIAS fontobene_qt5)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Test binary
+add_executable(fontobene_qt5_tests
+    main.cpp
+)
+
+# Compiler defines
+add_definitions(-DTESTFILEPATH="${CMAKE_CURRENT_SOURCE_DIR}/fonto.bene")
+
+# Fail on warnings
+target_compile_options(fontobene_qt5_tests PRIVATE -Werror -Wall -Wextra)
+
+# Linking
+target_link_libraries(fontobene_qt5_tests fontobene_qt5 Qt5::Core)
+
+# Output binary name
+set_target_properties(fontobene_qt5_tests PROPERTIES OUTPUT_NAME fontobene-qt5-tests)


### PR DESCRIPTION
Building and installing:

```
$ mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/usr
-- The CXX compiler identification is GNU 10.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build

$ make
Scanning dependencies of target fontobene_qt5
[  0%] Built target fontobene_qt5
Scanning dependencies of target fontobene_qt5_tests
[ 50%] Building CXX object tests/CMakeFiles/fontobene_qt5_tests.dir/main.cpp.o
[100%] Linking CXX executable fontobene-qt5-tests
[100%] Built target fontobene_qt5_tests

$ make install
[  0%] Built target fontobene_qt5
[100%] Built target fontobene_qt5_tests
Install the project...
-- Install configuration: ""
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/glyphlist.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/font.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/glyph.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/glyphlistaccessor.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/exception.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/helpers.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/header.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/fontobene.h
-- Installing: /home/danilo/Projects/librepcb/LibrePCB/libs/fontobene-qt5/build/usr/include/fontobene-qt5/glyphlistcache.h
```

The resulting files:

```
$ tree usr
usr
└── include
    └── fontobene-qt5
        ├── exception.h
        ├── font.h
        ├── fontobene.h
        ├── glyph.h
        ├── glyphlist.h
        ├── glyphlistaccessor.h
        ├── glyphlistcache.h
        ├── header.h
        └── helpers.h

2 directories, 9 files
```