### PR TITLE
Install header files into a subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+### Unreleased
+
+- [added] Support for CMake
+- [changed] The header files are now installed into a subdirectory, so instead
+  of `#include <fontobene.h>` you now need to use `#include <fontobene-qt5/fontobene.h>`.
+
 ### 0.1.0 (2020-05-18)
 
 - First release

--- a/fontobene-qt5/CMakeLists.txt
+++ b/fontobene-qt5/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(fontobene_qt5
 # Install target
 include(GNUInstallDirs)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fontobene-qt5
     FILES_MATCHING PATTERN "*.h"
 )
 

--- a/fontobene-qt5/fontobene-qt5.pro
+++ b/fontobene-qt5/fontobene-qt5.pro
@@ -24,5 +24,5 @@ HEADERS += \
 
 INSTALLS += headers
 
-headers.path = $$PREFIX/include/fontobene-qt5
+headers.path = $$PREFIX/include/fontobene-qt5/fontobene-qt5
 headers.files = $$HEADERS


### PR DESCRIPTION
Because the `/usr/include/fontobene-qt5` directory is on the include
path, we need to put the headers into a `fontobene-qt5` subdirectory
to ensure proper namespacing (`#include <fontobene-qt5/XYZ.h>`).

Based on #10, merge that one first.